### PR TITLE
Make no-std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ readme = "README.md"
 exclude = [".lazy.lua"]
 
 [dependencies]
-futures = { version = "0.3.31", optional = true }
+futures = { version = "0.3.31", optional = true, default-features = false }
 loom = { version = "0.7.2", optional = true }
 
 [features]
-loom = ["dep:loom"]
+default = ["std"]
+loom = ["dep:loom", "std"]
 async = ["dep:futures"]
+std = ["futures/std"]
 
 [[example]]
 name = "spsc_test"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The most optimized queue for 1-to-1 thread communication.
 
 ```rust
 use std::thread;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 use gil::spsc::channel;
 
 const COUNT: usize = 100_000;
@@ -39,7 +39,7 @@ Useful when multiple threads need to send data to a single worker thread.
 
 ```rust
 use std::thread;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 use gil::mpsc::channel;
 
 let (tx, mut rx) = channel::<usize>(NonZeroUsize::new(1024).unwrap());
@@ -67,7 +67,7 @@ The most flexible queue, allowing multiple senders and multiple receivers.
 
 ```rust
 use std::thread;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 use gil::mpmc::channel;
 
 let (tx, rx) = channel::<usize>(NonZeroUsize::new(1024).unwrap());
@@ -102,7 +102,7 @@ For high-throughput scenarios where multiple threads access the queue concurrent
 
 ```rust
 use std::thread;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 use gil::mpmc::sharded::channel;
 
 let max_shards = NonZeroUsize::new(8).unwrap();
@@ -132,7 +132,7 @@ gil = { version = "0.3", features = ["async"] }
 
 ```rust,ignore
 use gil::spsc::channel;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 const COUNT: usize = 100_000;
 
@@ -158,7 +158,7 @@ handle.await.unwrap();
 
 ```rust
 use gil::spsc::channel;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 let (mut tx, mut rx) = channel::<i32>(NonZeroUsize::new(10).unwrap());
 
@@ -181,8 +181,8 @@ For maximum performance, you can directly access the internal buffer. This allow
 
 ```rust
 use gil::spsc::channel;
-use std::ptr;
-use std::num::NonZeroUsize;
+use core::ptr;
+use core::num::NonZeroUsize;
 
 let (mut tx, mut rx) = channel::<usize>(NonZeroUsize::new(128).unwrap());
 
@@ -228,7 +228,7 @@ For large objects, consider using `Box<T>` to avoid the cost of copying the enti
 
 ```rust
 use gil::spsc::channel;
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 struct LargeStruct {
     data: [u8; 1024],

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,4 +1,4 @@
-use std::{mem::MaybeUninit, ptr::NonNull};
+use core::{mem::MaybeUninit, ptr::NonNull};
 
 use crate::atomic::AtomicUsize;
 
@@ -33,9 +33,9 @@ impl<T> CellPtr<T> {
 
     #[inline(always)]
     pub(crate) unsafe fn drop_in_place(&self) {
-        if std::mem::needs_drop::<T>() {
+        if core::mem::needs_drop::<T>() {
             unsafe {
-                std::ptr::drop_in_place(_field!(Cell<T>, self.ptr, data, T).as_ptr());
+                core::ptr::drop_in_place(_field!(Cell<T>, self.ptr, data, T).as_ptr());
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,42 @@
+#![no_std]
 #![doc = include_str!("../README.md")]
+
+extern crate alloc as alloc_crate;
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
+#[cfg(not(feature = "loom"))]
+pub(crate) use alloc_crate::alloc;
+pub(crate) use alloc_crate::boxed::Box;
 
 #[allow(unused_imports)]
 #[cfg(not(feature = "loom"))]
-pub(crate) use std::{
-    alloc, cell as std_cell, hint,
+pub(crate) use core::{
+    cell as std_cell, hint,
     sync::{self, atomic},
-    thread,
 };
+#[cfg(all(not(feature = "loom"), any(test, feature = "std")))]
+use std::thread;
+
+#[cfg(not(any(test, feature = "std", feature = "loom")))]
+pub(crate) mod thread {
+    pub(crate) use core::hint::spin_loop as yield_now;
+}
 
 #[allow(unused_imports)]
 #[cfg(feature = "loom")]
 pub(crate) use loom::{
-    alloc, cell as std_cell, hint,
+    cell as std_cell, hint,
     sync::{self, atomic},
     thread,
 };
+#[cfg(feature = "loom")]
+pub(crate) mod alloc {
+    pub use alloc_crate::alloc::handle_alloc_error;
+    pub use loom::alloc::Layout;
+    pub use loom::alloc::alloc;
+    pub use loom::alloc::dealloc;
+}
 
 #[allow(unused_macros)]
 macro_rules! _field {

--- a/src/mpmc/mod.rs
+++ b/src/mpmc/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! * [Dmitry Vyukov's Bounded MPMC Queue](http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue)
 
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 pub use self::{receiver::Receiver, sender::Sender};
 
@@ -45,7 +45,7 @@ pub mod sharded;
 /// # Examples
 ///
 /// ```
-/// use std::num::NonZeroUsize;
+/// use core::num::NonZeroUsize;
 /// use gil::mpmc::channel;
 ///
 /// let (tx, rx) = channel::<usize>(NonZeroUsize::new(1024).unwrap());

--- a/src/mpmc/queue.rs
+++ b/src/mpmc/queue.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     marker::PhantomData,
     mem::{align_of, size_of},
     num::NonZeroUsize,
@@ -57,7 +57,7 @@ impl<T> QueuePtr<T> {
         // SAFETY: capacity > 0, so layout is non-zero too
         let ptr = unsafe { alloc::alloc(layout) } as *mut Queue;
         let Some(ptr) = NonNull::new(ptr) else {
-            std::alloc::handle_alloc_error(layout);
+            alloc::handle_alloc_error(layout);
         };
 
         // calculate buffer pointer
@@ -77,7 +77,7 @@ impl<T> QueuePtr<T> {
         };
 
         // SAFETY: we just allocated it, and atomics are safe to access without initialisation
-        let buffer_slice = unsafe { std::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
+        let buffer_slice = unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
         for (idx, cell) in buffer_slice.iter_mut().enumerate() {
             cell.epoch.store(idx, Ordering::Relaxed);
         }
@@ -130,7 +130,7 @@ impl<T> Drop for QueuePtr<T> {
 
             let tail = self.tail().load(Ordering::Relaxed);
 
-            if std::mem::needs_drop::<T>() {
+            if core::mem::needs_drop::<T>() {
                 for i in 1..=self.capacity {
                     let idx = tail.wrapping_sub(i);
                     let cell = self.at(idx);

--- a/src/mpmc/receiver.rs
+++ b/src/mpmc/receiver.rs
@@ -46,7 +46,7 @@ impl<T> Receiver<T> {
     /// * `Some(value)` if a value is available.
     /// * `None` if the queue is empty.
     pub fn try_recv(&mut self) -> Option<T> {
-        use std::cmp::Ordering as Cmp;
+        use core::cmp::Ordering as Cmp;
 
         let mut backoff = crate::Backoff::with_spin_count(16);
 

--- a/src/mpmc/sender.rs
+++ b/src/mpmc/sender.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering as Cmp;
+use core::cmp::Ordering as Cmp;
 
 use crate::{atomic::Ordering, mpmc::queue::QueuePtr};
 

--- a/src/mpmc/sharded/mod.rs
+++ b/src/mpmc/sharded/mod.rs
@@ -64,6 +64,7 @@ mod test {
     use super::*;
 
     use crate::thread;
+    use alloc_crate::vec;
 
     #[test]
     fn basic() {

--- a/src/mpmc/sharded/receiver.rs
+++ b/src/mpmc/sharded/receiver.rs
@@ -1,7 +1,7 @@
 use core::ptr::{self, NonNull};
 
 use crate::{
-    Backoff,
+    Backoff, Box,
     padded::Padded,
     spsc::{self, shards::ShardsPtr},
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -18,7 +18,7 @@ pub struct ReadGuard<'a, T> {
     consumed: usize,
 }
 
-impl<'a, T> std::ops::Deref for ReadGuard<'a, T> {
+impl<'a, T> core::ops::Deref for ReadGuard<'a, T> {
     type Target = [T];
     fn deref(&self) -> &Self::Target {
         unsafe { self.data.as_ref() }

--- a/src/mpmc/sharded/sender.rs
+++ b/src/mpmc/sharded/sender.rs
@@ -1,6 +1,7 @@
 use core::{mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull};
 
 use crate::{
+    Box,
     spsc::{self, shards::ShardsPtr},
     sync::atomic::{AtomicUsize, Ordering},
 };

--- a/src/mpsc/mod.rs
+++ b/src/mpsc/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! * Adapted from [Dmitry Vyukov's Bounded MPMC Queue](http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue)
 
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 pub use self::{receiver::Receiver, sender::Sender};
 
@@ -42,7 +42,7 @@ pub mod sharded;
 /// # Examples
 ///
 /// ```
-/// use std::num::NonZeroUsize;
+/// use core::num::NonZeroUsize;
 /// use gil::mpsc::channel;
 ///
 /// let (tx, rx) = channel::<usize>(NonZeroUsize::new(1024).unwrap());

--- a/src/mpsc/queue.rs
+++ b/src/mpsc/queue.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     marker::PhantomData,
     mem::{align_of, size_of},
     num::NonZeroUsize,
@@ -56,7 +56,7 @@ impl<T> QueuePtr<T> {
         // SAFETY: capacity > 0, so layout is non-zero too
         let ptr = unsafe { alloc::alloc(layout) } as *mut Queue;
         let Some(ptr) = NonNull::new(ptr) else {
-            std::alloc::handle_alloc_error(layout);
+            alloc::handle_alloc_error(layout);
         };
 
         // calculate buffer pointer
@@ -75,7 +75,7 @@ impl<T> QueuePtr<T> {
         };
 
         // SAFETY: we just allocated it, and atomics are safe to access without initialisation
-        let buffer_slice = unsafe { std::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
+        let buffer_slice = unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
         for (idx, cell) in buffer_slice.iter_mut().enumerate() {
             cell.epoch.store(idx, Ordering::Relaxed);
         }
@@ -123,7 +123,7 @@ impl<T> Drop for QueuePtr<T> {
 
             let tail = self.tail().load(Ordering::Relaxed);
 
-            if std::mem::needs_drop::<T>() {
+            if core::mem::needs_drop::<T>() {
                 for i in 1..=self.capacity {
                     let idx = tail.wrapping_sub(i);
                     let cell = self.at(idx);

--- a/src/mpsc/sender.rs
+++ b/src/mpsc/sender.rs
@@ -44,7 +44,7 @@ impl<T> Sender<T> {
     /// * `Ok(())` if the value was successfully sent.
     /// * `Err(value)` if the queue is full, returning the original value.
     pub fn try_send(&mut self, value: T) -> Result<(), T> {
-        use std::cmp::Ordering as Cmp;
+        use core::cmp::Ordering as Cmp;
 
         let mut backoff = crate::Backoff::with_spin_count(16);
 

--- a/src/mpsc/sharded/mod.rs
+++ b/src/mpsc/sharded/mod.rs
@@ -61,6 +61,7 @@ mod test {
     use super::*;
 
     use crate::thread;
+    use alloc_crate::vec;
 
     #[test]
     fn basic() {

--- a/src/mpsc/sharded/receiver.rs
+++ b/src/mpsc/sharded/receiver.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Backoff,
+    Backoff, Box,
     spsc::{self, shards::ShardsPtr},
 };
 
@@ -73,7 +73,7 @@ impl<T> Receiver<T> {
             let ret = self.receivers[self.next_shard].read_buffer();
 
             if !ret.is_empty() {
-                return unsafe { std::mem::transmute::<&[T], &[T]>(ret) };
+                return unsafe { core::mem::transmute::<&[T], &[T]>(ret) };
             }
 
             self.next_shard += 1;

--- a/src/mpsc/sharded/sender.rs
+++ b/src/mpsc/sharded/sender.rs
@@ -1,6 +1,7 @@
 use core::{mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull};
 
 use crate::{
+    Box,
     spsc::{self, shards::ShardsPtr},
     sync::atomic::{AtomicUsize, Ordering},
 };

--- a/src/spmc/mod.rs
+++ b/src/spmc/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! * Adapted from [Dmitry Vyukov's Bounded MPMC Queue](http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue)
 
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 pub use self::{receiver::Receiver, sender::Sender};
 

--- a/src/spmc/queue.rs
+++ b/src/spmc/queue.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     marker::PhantomData,
     mem::{align_of, size_of},
     num::NonZeroUsize,
@@ -51,7 +51,7 @@ impl<T> QueuePtr<T> {
 
         let ptr = unsafe { alloc::alloc(layout) } as *mut Queue;
         let Some(ptr) = NonNull::new(ptr) else {
-            std::alloc::handle_alloc_error(layout);
+            alloc::handle_alloc_error(layout);
         };
 
         let buffer = unsafe {
@@ -65,7 +65,7 @@ impl<T> QueuePtr<T> {
             });
         };
 
-        let buffer_slice = unsafe { std::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
+        let buffer_slice = unsafe { core::slice::from_raw_parts_mut(buffer.as_ptr(), capacity) };
         for (idx, cell) in buffer_slice.iter_mut().enumerate() {
             cell.epoch.store(idx, Ordering::Relaxed);
         }
@@ -112,7 +112,7 @@ impl<T> Drop for QueuePtr<T> {
 
             let head = self.head().load(Ordering::Relaxed);
 
-            if std::mem::needs_drop::<T>() {
+            if core::mem::needs_drop::<T>() {
                 for i in 0..self.capacity {
                     let idx = head.wrapping_add(i);
                     let cell = self.at(idx);

--- a/src/spmc/receiver.rs
+++ b/src/spmc/receiver.rs
@@ -31,7 +31,7 @@ impl<T> Receiver<T> {
     }
 
     pub fn try_recv(&mut self) -> Option<T> {
-        use std::cmp::Ordering as Cmp;
+        use core::cmp::Ordering as Cmp;
 
         let mut backoff = crate::Backoff::with_spin_count(16);
         loop {

--- a/src/spsc/mod.rs
+++ b/src/spsc/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! * [Facebook Folly ProducerConsumerQueue](https://github.com/facebook/folly/blob/main/folly/ProducerConsumerQueue.h)
 
-use std::num::NonZeroUsize;
+use core::num::NonZeroUsize;
 
 pub(crate) use self::queue::QueuePtr;
 pub(crate) mod shards;
@@ -44,7 +44,7 @@ mod sender;
 /// # Examples
 ///
 /// ```
-/// use std::num::NonZeroUsize;
+/// use core::num::NonZeroUsize;
 /// use gil::spsc::channel;
 ///
 /// let (tx, rx) = channel::<usize>(NonZeroUsize::new(1024).unwrap());
@@ -195,7 +195,7 @@ mod test {
 
 #[cfg(all(test, feature = "loom"))]
 mod loom_test {
-    use std::num::NonZeroUsize;
+    use core::num::NonZeroUsize;
 
     use super::*;
     use crate::thread;

--- a/src/spsc/queue.rs
+++ b/src/spsc/queue.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "async")]
-use std::task::Waker;
-use std::{
+use core::task::Waker;
+use core::{
     marker::PhantomData,
     mem::{align_of, size_of},
     num::NonZeroUsize,
@@ -72,7 +72,7 @@ impl<T> QueuePtr<T> {
 
         // SAFETY: capacity > 0, so layout is non-zero too
         let Some(ptr) = NonNull::new(unsafe { alloc::alloc(layout) }) else {
-            std::alloc::handle_alloc_error(layout);
+            alloc::handle_alloc_error(layout);
         };
         let ptr = ptr.cast::<Queue>();
 
@@ -211,11 +211,11 @@ impl<T> Drop for QueuePtr<T> {
             let tail = self.tail().load(Ordering::Relaxed);
             let len = tail.wrapping_sub(head);
 
-            if std::mem::needs_drop::<T>() {
+            if core::mem::needs_drop::<T>() {
                 for i in 0..len {
                     let idx = head.wrapping_add(i);
                     unsafe {
-                        std::ptr::drop_in_place(self.at(idx).as_ptr());
+                        core::ptr::drop_in_place(self.at(idx).as_ptr());
                     }
                 }
             }

--- a/src/spsc/receiver.rs
+++ b/src/spsc/receiver.rs
@@ -78,7 +78,7 @@ impl<T> Receiver<T> {
     /// This method yields the current task if the queue is empty.
     #[cfg(feature = "async")]
     pub async fn recv_async(&mut self) -> T {
-        use std::task::Poll;
+        use core::task::Poll;
 
         if self.local_head == self.local_tail {
             futures::future::poll_fn(|ctx| {
@@ -140,7 +140,7 @@ impl<T> Receiver<T> {
 
         unsafe {
             let ptr = self.ptr.exact_at(start);
-            std::slice::from_raw_parts(ptr.as_ptr(), len)
+            core::slice::from_raw_parts(ptr.as_ptr(), len)
         }
     }
 

--- a/src/spsc/sender.rs
+++ b/src/spsc/sender.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 use crate::{atomic::Ordering, spsc::queue::QueuePtr};
 
@@ -67,7 +67,7 @@ impl<T> Sender<T> {
     /// This method yields the current task if the queue is full.
     #[cfg(feature = "async")]
     pub async fn send_async(&mut self, value: T) {
-        use std::task::Poll;
+        use core::task::Poll;
 
         let new_tail = self.local_tail.wrapping_add(1);
 
@@ -116,8 +116,8 @@ impl<T> Sender<T> {
     ///
     /// # Usage
     ///
-    /// It returns a slice of [`MaybeUninit`](std::mem::MaybeUninit) to prevent UB, you can use
-    /// [`copy_nonoverlapping`](std::ptr::copy_nonoverlapping) if you want fast copying between
+    /// It returns a slice of [`MaybeUninit`](core::mem::MaybeUninit) to prevent UB, you can use
+    /// [`copy_nonoverlapping`](core::ptr::copy_nonoverlapping) if you want fast copying between
     /// this and your own data.
     pub fn write_buffer(&mut self) -> &mut [MaybeUninit<T>] {
         let mut available = self.ptr.size - self.local_tail.wrapping_sub(self.local_head);
@@ -133,7 +133,7 @@ impl<T> Sender<T> {
 
         unsafe {
             let ptr = self.ptr.exact_at(start).cast();
-            std::slice::from_raw_parts_mut(ptr.as_ptr(), len)
+            core::slice::from_raw_parts_mut(ptr.as_ptr(), len)
         }
     }
 

--- a/src/spsc/shards.rs
+++ b/src/spsc/shards.rs
@@ -17,7 +17,7 @@ impl<T> Shards<T> {
     pub fn new(max_shards: NonZeroUsize) -> NonNull<Self> {
         let layout = Self::layout(max_shards.get());
         let Some(ptr) = NonNull::new(unsafe { alloc::alloc(layout) }) else {
-            std::alloc::handle_alloc_error(layout)
+            alloc::handle_alloc_error(layout)
         };
 
         unsafe { ptr.cast::<AtomicUsize>().write(AtomicUsize::new(1)) };


### PR DESCRIPTION
I noticed that you don't actually use anything that requires `std`. So it was quite easy to make this `no-std` compatible.
Making loom work was a little tricky because it does not support `handle_alloc_error` but I made it work.
